### PR TITLE
Add support for transfering files accross the network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.full
 Gemfile.lock
 client/client
+fakessh/fakessh
 libadjust/libadjust.a
 libadjust/libadjust_p.a
+radjust/radjust
 server/server

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SUBDIR=	libadjust client server
+SUBDIR=	libadjust client server radjust fakessh
 
 CFLAGS+=	-I../libadjust
 

--- a/fakessh/Makefile
+++ b/fakessh/Makefile
@@ -1,0 +1,4 @@
+PROG=		fakessh
+WITHOUT_MAN=
+
+.include <bsd.prog.mk>

--- a/fakessh/fakessh.c
+++ b/fakessh/fakessh.c
@@ -1,0 +1,76 @@
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+void		 usage(void);
+
+const char *progname;
+struct {
+    struct {
+	int port;
+	char host[255];
+	int hostport;
+    } R;
+    char *user;
+    char *hostname;
+} options;
+
+int
+main(int argc, char *argv[])
+{
+    int ch;
+    progname = argv[0];
+
+    while ((ch = getopt(argc, argv, "R:")) != -1) {
+	switch (ch) {
+	case 'R':
+	    if (sscanf(optarg, "%d:%[^:]:%d", &options.R.port, options.R.host, &options.R.hostport) != 3)
+		exit(EXIT_FAILURE);
+
+	    if (options.R.port == 0) {
+		if (strcmp(options.R.host, "127.0.0.1") == 0) {
+		    fprintf(stderr, "Allocated port %d for remote forward to %s:%d\n", options.R.hostport, options.R.host, options.R.hostport);
+		} else {
+		    fprintf(stderr, "Fake -R only supports 127.0.0.1 as host.\n");
+		    exit(EXIT_FAILURE);
+		}
+	    }
+	    break;
+	case '?':
+	default:
+	    usage();
+	    break;
+	}
+    }
+
+    argc -= optind;
+    argv += optind;
+
+    if (argc < 2)
+	usage();
+
+    char *p = strchr(argv[0], '@');
+    if (p) {
+	options.user = argv[0];
+	options.hostname = p + 1;
+    } else {
+	options.user = NULL;
+	options.hostname = argv[0];
+    }
+
+    argc -= 1;
+    argv += 1;
+
+    if (execvp(argv[0], argv) < 0)
+	perror("execvp");
+
+    exit(EXIT_SUCCESS);
+}
+
+void
+usage(void)
+{
+    fprintf(stderr, "usage: %s [-R port:host:hostport] [user@]hostname [command]\n", progname);
+    exit(EXIT_FAILURE);
+}

--- a/fakessh/fakessh.c
+++ b/fakessh/fakessh.c
@@ -1,3 +1,4 @@
+#include <err.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -62,9 +63,11 @@ main(int argc, char *argv[])
     argc -= 1;
     argv += 1;
 
-    if (execvp(argv[0], argv) < 0)
-	perror("execvp");
+    if (execvp(argv[0], argv) < 0) {
+	err(EXIT_FAILURE, "execvp");
+    }
 
+    /* NOTREACHED */
     exit(EXIT_SUCCESS);
 }
 

--- a/features/radjust.feature
+++ b/features/radjust.feature
@@ -1,0 +1,55 @@
+Feature: File adjustement
+  Scenario: Adjust inexistent remote destination file
+    Given a random file "source" exists and is 42 B
+    And a file "target" does not exist
+    When I synchronize local "source" -> remote "target"
+    Then the file "target" should exist
+    And the file "target" sould be 42 B long
+    And "source" and "target" should have the same mtime
+    And "source" and "target" should have the same content
+
+  Scenario: Adjust inexistent local destination file
+    Given a random file "source" exists and is 42 B
+    And a file "target" does not exist
+    When I synchronize remote "source" -> local "target"
+    Then the file "target" should exist
+    And the file "target" sould be 42 B long
+    And "source" and "target" should have the same mtime
+    And "source" and "target" should have the same content
+
+  Scenario: Adjust smaller remote destination file
+    Given a random file "source" exists and is 42 B
+    And a random file "target" exists and is 41 B
+    When I synchronize local "source" -> remote "target"
+    Then the file "target" should exist
+    And the file "target" sould be 42 B long
+    And "source" and "target" should have the same mtime
+    And "source" and "target" should have the same content
+
+  Scenario: Adjust smaller local destination file
+    Given a random file "source" exists and is 42 B
+    And a random file "target" exists and is 41 B
+    When I synchronize remote "source" -> local "target"
+    Then the file "target" should exist
+    And the file "target" sould be 42 B long
+    And "source" and "target" should have the same mtime
+    And "source" and "target" should have the same content
+
+  Scenario: Adjust larger remote destination file
+    Given a random file "source" exists and is 42 B
+    And a random file "target" exists and is 41 KB
+    When I synchronize local "source" -> remote "target"
+    Then the file "target" should exist
+    And the file "target" sould be 42 B long
+    And "source" and "target" should have the same mtime
+    And "source" and "target" should have the same content
+
+  Scenario: Adjust larger local destination file
+    Given a random file "source" exists and is 42 B
+    And a random file "target" exists and is 41 KB
+    When I synchronize remote "source" -> local "target"
+    Then the file "target" should exist
+    And the file "target" sould be 42 B long
+    And "source" and "target" should have the same mtime
+    And "source" and "target" should have the same content
+

--- a/features/step_definitions/radjust.rb
+++ b/features/step_definitions/radjust.rb
@@ -25,3 +25,13 @@ When(/^I synchronize "([^"]*)" \-> "([^"]*)"$/) do |source, destination|
   client_stdout.close
   client_stderr.close
 end
+
+When(/^I synchronize local "([^"]*)" \-> remote "([^"]*)"$/) do |source, destination|
+  `env PATH=radjust radjust -e fakessh/fakessh #{tmp_file_name(source)} user@host:#{tmp_file_name(destination)}`
+  expect($?.success?).to be true
+end
+
+When(/^I synchronize remote "([^"]*)" \-> local "([^"]*)"$/) do |source, destination|
+  `env PATH=radjust radjust -e fakessh/fakessh user@host:#{tmp_file_name(source)} #{tmp_file_name(destination)}`
+  expect($?.success?).to be true
+end

--- a/radjust/Makefile
+++ b/radjust/Makefile
@@ -1,0 +1,19 @@
+OS!=		uname -s
+
+PROG=		radjust
+WITHOUT_MAN=
+CFLAGS+=	-I../libadjust
+.if ${OS} == "FreeBSD"
+LDFLAGS+=	-lmd
+.endif
+LDADD+=		../libadjust/libadjust.a
+.if ${OS} == "Linux"
+CFLAGS+=	-D_GNU_SOURCE
+LDADD+=		-lcrypto
+.endif
+
+.include <bsd.prog.mk>
+
+coin:
+	scp Makefile radjust.c schnocdlu:radjust/radjust/
+	ssh schnocdlu cd radjust/radjust '&&' fmake '&&' fmake install

--- a/radjust/radjust.c
+++ b/radjust/radjust.c
@@ -1,0 +1,221 @@
+#include <err.h>
+#include <getopt.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "adjust.h"
+
+#include <unistd.h>
+
+const char *progname;
+
+void		 usage(void);
+int		 start_client(int argc, char *argv[]);
+int		 start_server(int argc, char *argv[]);
+bool		 is_remote(const char *subject);
+void		 extract_remote_host_and_filename(char *subject, char **remote_host, char **filename);
+int		 transmit(char *filename);
+
+struct {
+    int client;
+    int recv;
+    int send;
+    char *rsh;
+} options = {
+    0,
+    0,
+    0,
+    "ssh",
+};
+
+static struct option longopts[] = {
+    { "client", no_argument,       &options.client, 1,   },
+    { "recv",   no_argument,       &options.recv,   1,   },
+    { "send",   no_argument,       &options.send,   1,   },
+    { "rsh",    required_argument, NULL,            'e', },
+    { NULL,     0,                 NULL,            0,   },
+};
+
+int
+main(int argc, char *argv[])
+{
+    progname = argv[0];
+
+    int ch;
+    while ((ch = getopt_long(argc, argv, "e:", longopts, NULL)) != -1) {
+	switch (ch) {
+	case 0:
+	    break;
+	case 'e':
+	    options.rsh = optarg;
+	    break;
+	default:
+	    usage();
+	    break;
+	}
+    }
+    argc -= optind;
+    argv += optind;
+
+    if (!options.send && !options.recv) {
+	if (is_remote(argv[0]))
+	    options.recv = 1;
+	if (is_remote(argv[argc - 1]))
+	    options.send = 1;
+    }
+
+    if (options.send && options.recv) {
+	fprintf(stderr, "Options --send and --recv are mutualy exclusive\n");
+	exit(EXIT_FAILURE);
+    }
+
+    if (options.client) {
+	start_client(argc, argv);
+    } else {
+	start_server(argc, argv);
+    }
+
+    exit(EXIT_SUCCESS);
+}
+
+void
+usage(void)
+{
+    fprintf(stderr, "usage: %s [options] source destination\n", progname);
+    exit(EXIT_FAILURE);
+}
+
+int
+start_client(int argc, char *argv[])
+{
+    if (argc != 1)
+	usage();
+
+    char buffer[BUFSIZ];
+    fgets(buffer, sizeof(buffer), stdin);
+
+    int port;
+    if (sscanf(buffer, "%d\n", &port) < 0)
+	return -1;
+
+    if (libadjust_socket_open_out(port) < 0)
+	errx(EXIT_FAILURE, "libadjust_socket_open_out");
+
+    if (transmit(argv[0]) < 0)
+	errx(EXIT_FAILURE, "transmit");
+
+    libadjust_socket_close();
+
+    return 0;
+}
+
+int
+start_server(int argc, char *argv[])
+{
+    if (argc != 2)
+	usage();
+
+    int local_port = libadjust_socket_open_in();
+    if (local_port < 0)
+	errx(EXIT_FAILURE, "libadjust_socket_open_in");
+
+    char *remote_host, *remote_filename;
+    char *local_filename;
+
+    char *client_flags = "";
+    if (options.send) {
+	client_flags = "--recv";
+	local_filename = argv[0];
+	extract_remote_host_and_filename(argv[1], &remote_host, &remote_filename);
+    } else {
+	client_flags = "--send";
+	extract_remote_host_and_filename(argv[0], &remote_host, &remote_filename);
+	local_filename = argv[1];
+    }
+
+    char *cmd;
+    asprintf(&cmd, "%s -R 0:127.0.0.1:%d %s radjust --client %s %s 2>&1", options.rsh, local_port, remote_host, client_flags, remote_filename);
+
+    FILE *f;
+
+    if (!(f = popen(cmd, "r+"))) {
+	fprintf(stderr, "popen\n");
+	goto fail;
+    }
+
+    char buffer[BUFSIZ];
+    if (!fgets(buffer, sizeof(buffer), f)) {
+	fprintf(stderr, "fgets\n");
+	goto fail;
+    }
+
+    int remote_port;
+    if (sscanf(buffer, "Allocated port %d for remote forward to", &remote_port) != 1) {
+	fprintf(stderr, "can't read port number\n");
+	goto fail;
+    }
+
+    fprintf(f, "%d\n", remote_port);
+    fflush(f);
+
+    if (libadjust_socket_open_in_accept() < 0)
+	errx(EXIT_FAILURE, "libadjust_socket_open_in_accept");
+
+    if (transmit(local_filename) < 0)
+	errx(EXIT_FAILURE, "transmit");
+
+fail:
+    libadjust_socket_close();
+    if (pclose(f) < 0) {
+	err(EXIT_FAILURE, "pclose");
+    }
+    free(cmd);
+
+    return 0;
+}
+
+int
+transmit(char *filename)
+{
+    int res = -1;
+
+    if (options.send)
+	res = libadjust_send_file(filename);
+
+    if (options.recv)
+	res = libadjust_recv_file(filename);
+
+    if (res < 0)
+	libadjust_error_print(stderr);
+
+    return res;
+}
+
+void
+extract_remote_host_and_filename(char *subject, char **remote_host, char **filename)
+{
+    if (is_remote(subject)) {
+	char *colon = strchr(subject, ':');
+
+	*colon = '\0';
+	*remote_host = subject;
+	*filename = colon + 1;
+    } else {
+	*remote_host = NULL;
+	*filename = subject;
+    }
+}
+
+bool
+is_remote(const char *subject)
+{
+    char *slash = strchr(subject, '/');
+    char *colon = strchr(subject, ':');
+
+    if ((colon && !slash) || (colon && slash && colon < slash))
+	return true;
+    else
+	return false;
+}


### PR DESCRIPTION
`rsync(1)` has an option `-e, --rsh=COMMAND` and an environment variable `RSYNC_RSH` to specify the remote shell to use that could be copied.