### PR TITLE
Add an option to only append missing data

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -8,8 +8,8 @@ Feature: File adjustement
     And "source" and "target" should have the same mtime
     And "source" and "target" should have the same content
     And the client should have sent 78 B
-    And the client should have received 1 B
-    And the server should have sent 1 B
+    And the client should have received 3 B
+    And the server should have sent 3 B
     And the server should have received 78 B
     And 0 block should have been synchronized
     And 0 chunk should have been synchronized
@@ -24,8 +24,8 @@ Feature: File adjustement
     And "source" and "target" should have the same mtime
     And "source" and "target" should have the same content
     And the client should have sent 111 B
-    And the client should have received 34 B
-    And the server should have sent 34 B
+    And the client should have received 36 B
+    And the server should have sent 36 B
     And the server should have received 111 B
     And 1 block should have been synchronized
     And 1 chunk should have been synchronized
@@ -40,8 +40,8 @@ Feature: File adjustement
     And "source" and "target" should have the same mtime
     And "source" and "target" should have the same content
     And the client should have sent 111 B
-    And the client should have received 34 B
-    And the server should have sent 34 B
+    And the client should have received 37 B
+    And the server should have sent 37 B
     And the server should have received 111 B
     And 1 block should have been synchronized
     And 1 chunk should have been synchronized
@@ -55,8 +55,8 @@ Feature: File adjustement
     And "source" and "target" should have the same mtime
     And "source" and "target" should have the same content
     And the client should have sent 36 B
-    And the client should have received 1 B
-    And the server should have sent 1 B
+    And the client should have received 4 B
+    And the server should have sent 4 B
     And the server should have received 36 B
     And 0 block should have been synchronized
     And 0 chunk should have been synchronized
@@ -71,8 +71,8 @@ Feature: File adjustement
     And "source" and "target" should have the same mtime
     And "source" and "target" should have the same content
     And the client should have sent 111 B
-    And the client should have received 34 B
-    And the server should have sent 34 B
+    And the client should have received 39 B
+    And the server should have sent 39 B
     And the server should have received 111 B
     And 1 block should have been synchronized
     And 1 chunk should have been synchronized
@@ -86,8 +86,8 @@ Feature: File adjustement
     And "source" and "target" should have the same mtime
     And "source" and "target" should have the same content
     And the client should have sent 8330 B
-    And the client should have received 131076 B
-    And the server should have sent 131076 B
+    And the client should have received 131085 B
+    And the server should have sent 131085 B
     And the server should have received 8330 B
     And 1 block should have been synchronized
     And 1 chunk should have been synchronized

--- a/features/core.feature
+++ b/features/core.feature
@@ -63,7 +63,7 @@ Feature: File adjustement
 
   Scenario: Adjust larger destination file
     Given a random file "source" exists and is 42 B
-    And a random file "target" exists and is 4 KB
+    And a random file "target" exists and is 4 KiB
     And "source" and "target" have different mtime
     When I synchronize "source" -> "target"
     Then the file "target" should exist
@@ -78,7 +78,7 @@ Feature: File adjustement
     And 1 chunk should have been synchronized
 
   Scenario: Transfer only changed chunks
-    Given a random file "source" exists and is 42 MB
+    Given a random file "source" exists and is 42 MiB
     And "target" is a copy of "source" with 1 byte changed
     And "source" and "target" have different mtime
     When I synchronize "source" -> "target"

--- a/features/step_definitions/file_management.rb
+++ b/features/step_definitions/file_management.rb
@@ -126,5 +126,5 @@ Then(/^(\d+) block should have been synchronized$/) do |n|
 end
 
 Then(/^(\d+) chunk should have been synchronized$/) do |n|
-  expect(@client_stdout).to match(/^#{n} chunks/)
+  expect(@client_stdout).to match(/in #{n} chunks/)
 end

--- a/features/support/transforms.rb
+++ b/features/support/transforms.rb
@@ -1,8 +1,8 @@
 FILESIZE = Transform(/(\d+) ?([KMG])?(i)?B/) do |size, unit, si|
   multiplier = if si == 'i'
-                 1000
-               else
                  1024
+               else
+                 1000
                end
 
   power = [nil, 'K', 'M', 'G'].index(unit)

--- a/libadjust/adjust_internal.h
+++ b/libadjust/adjust_internal.h
@@ -50,8 +50,8 @@ void			 file_info_free(struct file_info *info);
 int			 file_open(struct file_info *file, int mode) __attribute__((warn_unused_result));
 int			 file_close(struct file_info *file) __attribute__((warn_unused_result));
 
-int			 send_whole_file_content(const int fd, struct file_info *local) __attribute__((warn_unused_result));
-int			 recv_whole_file_content(const int fd, struct file_info *local) __attribute__((warn_unused_result));
+int			 send_end_of_file(const int fd, struct file_info *local) __attribute__((warn_unused_result));
+int			 recv_end_of_file(const int fd, struct file_info *local) __attribute__((warn_unused_result));
 
 int			 send_file_adjustments(const int fd, struct file_info *local, const struct file_info *remote) __attribute__((warn_unused_result));
 int			 recv_file_adjustments(const int fd, struct file_info *local, const struct file_info *remote) __attribute__((warn_unused_result));

--- a/libadjust/adjust_internal.h
+++ b/libadjust/adjust_internal.h
@@ -32,6 +32,8 @@ struct libadjust_stats {
     size_t bytes_synchronized;
     size_t bytes_send;
     size_t bytes_recv;
+    size_t bytes_adjusted;
+    size_t bytes_send_raw;
     int adjusted_blocks;
     int adjusted_chunks;
 };

--- a/libadjust/adjust_internal.h
+++ b/libadjust/adjust_internal.h
@@ -72,6 +72,8 @@ int			 file_recv_content(const int fd, struct file_info *local) __attribute__((w
 
 void			 sha256(const void *data, const size_t length, unsigned char digest[32]);
 
+int			 recv_line(char *buffer, size_t length);
+
 int			 recv_data(int fd, void *data, size_t length) __attribute__((warn_unused_result));
 int			 send_data(int fd, void *data, size_t length) __attribute__((warn_unused_result));
 

--- a/libadjust/adjust_internal.h
+++ b/libadjust/adjust_internal.h
@@ -21,8 +21,6 @@ struct file_info {
     off_t size;
     struct timespec mtime;
 
-    enum {TM_WHOLE_FILE, TM_ADJUST} transfer_mode;
-
     int fd;
     off_t offset;
     void *data;
@@ -53,8 +51,8 @@ int			 file_close(struct file_info *file) __attribute__((warn_unused_result));
 int			 send_whole_file_content(const int fd, struct file_info *local) __attribute__((warn_unused_result));
 int			 recv_whole_file_content(const int fd, struct file_info *local) __attribute__((warn_unused_result));
 
-int			 send_file_adjustments(const int fd, struct file_info *local) __attribute__((warn_unused_result));
-int			 recv_file_adjustments(const int fd, struct file_info *local) __attribute__((warn_unused_result));
+int			 send_file_adjustments(const int fd, struct file_info *local, const struct file_info *remote) __attribute__((warn_unused_result));
+int			 recv_file_adjustments(const int fd, struct file_info *local, const struct file_info *remote) __attribute__((warn_unused_result));
 
 int			 send_block_adjustments(const int fd, const struct file_info *file) __attribute__((warn_unused_result));
 int			 recv_block_adjustments(const int fd, const struct file_info *file) __attribute__((warn_unused_result));
@@ -64,11 +62,11 @@ int			 file_map_next_block(struct file_info *file) __attribute__((warn_unused_re
 int			 file_set_size(struct file_info *file, const off_t size) __attribute__((warn_unused_result));
 int			 file_set_mtime(const struct file_info *file, const struct timespec mtime) __attribute__((warn_unused_result));
 
-int			 file_send(const int fd, struct file_info *local) __attribute__((warn_unused_result));
+int			 file_send(const int fd, struct file_info *local, const struct file_info *remote) __attribute__((warn_unused_result));
 int			 file_recv(const int fd, struct file_info *local, const struct file_info *remote) __attribute__((warn_unused_result));
 
-int			 file_send_content(const int fd, struct file_info *local) __attribute__((warn_unused_result));
-int			 file_recv_content(const int fd, struct file_info *local) __attribute__((warn_unused_result));
+int			 file_send_content(const int fd, struct file_info *local, const struct file_info *remote) __attribute__((warn_unused_result));
+int			 file_recv_content(const int fd, struct file_info *local, const struct file_info *remote) __attribute__((warn_unused_result));
 
 void			 sha256(const void *data, const size_t length, unsigned char digest[32]);
 

--- a/libadjust/adjust_internal.h
+++ b/libadjust/adjust_internal.h
@@ -50,11 +50,11 @@ void			 file_info_free(struct file_info *info);
 int			 file_open(struct file_info *file, int mode) __attribute__((warn_unused_result));
 int			 file_close(struct file_info *file) __attribute__((warn_unused_result));
 
-int			 send_whole_file_content(const int fd, struct file_info *file) __attribute__((warn_unused_result));
-int			 recv_whole_file_content(const int fd, struct file_info *file) __attribute__((warn_unused_result));
+int			 send_whole_file_content(const int fd, struct file_info *local) __attribute__((warn_unused_result));
+int			 recv_whole_file_content(const int fd, struct file_info *local) __attribute__((warn_unused_result));
 
-int			 send_file_adjustments(const int fd, struct file_info *file) __attribute__((warn_unused_result));
-int			 recv_file_adjustments(const int fd, struct file_info *file) __attribute__((warn_unused_result));
+int			 send_file_adjustments(const int fd, struct file_info *local) __attribute__((warn_unused_result));
+int			 recv_file_adjustments(const int fd, struct file_info *local) __attribute__((warn_unused_result));
 
 int			 send_block_adjustments(const int fd, const struct file_info *file) __attribute__((warn_unused_result));
 int			 recv_block_adjustments(const int fd, const struct file_info *file) __attribute__((warn_unused_result));
@@ -64,11 +64,11 @@ int			 file_map_next_block(struct file_info *file) __attribute__((warn_unused_re
 int			 file_set_size(struct file_info *file, const off_t size) __attribute__((warn_unused_result));
 int			 file_set_mtime(const struct file_info *file, const struct timespec mtime) __attribute__((warn_unused_result));
 
-int			 file_send(const int fd, struct file_info *file) __attribute__((warn_unused_result));
+int			 file_send(const int fd, struct file_info *local) __attribute__((warn_unused_result));
 int			 file_recv(const int fd, struct file_info *local, const struct file_info *remote) __attribute__((warn_unused_result));
 
-int			 file_send_content(const int fd, struct file_info *file) __attribute__((warn_unused_result));
-int			 file_recv_content(const int fd, struct file_info *file) __attribute__((warn_unused_result));
+int			 file_send_content(const int fd, struct file_info *local) __attribute__((warn_unused_result));
+int			 file_recv_content(const int fd, struct file_info *local) __attribute__((warn_unused_result));
 
 void			 sha256(const void *data, const size_t length, unsigned char digest[32]);
 

--- a/libadjust/file.c
+++ b/libadjust/file.c
@@ -56,17 +56,8 @@ int
 libadjust_recv_file(char *filename)
 {
     char buffer[BUFSIZ];
-    char *p = buffer;
-
-    if (recv_data(sock, p, 1) != 1)
-	FAILX(-1, "recv_data");
-
-    while (*p != '\n') {
-	p++;
-	if (recv_data(sock, p, 1) != 1)
-	    FAILX(-1, "recv_data");
-    }
-    *p = '\0';
+    if (recv_line(buffer, sizeof(buffer)) < 0)
+	FAILX(-1, "read_line");
 
     char remote_filename[BUFSIZ];
 

--- a/libadjust/file.c
+++ b/libadjust/file.c
@@ -40,6 +40,15 @@ libadjust_send_file(char *filename)
     if (send_data(sock, buffer, strlen(buffer)) != (int) strlen(buffer))
 	FAILX(-1, "send_data");
 
+    struct file_info *remote;
+    remote = file_info_alloc();
+
+    if (recv_line(buffer, sizeof(buffer)) < 0)
+	FAILX(-1, "read_line");
+
+    if (sscanf(buffer, "%ld", &remote->size) != 1)
+	FAILX(-1, "sscanf");
+
     if (file_send(sock, info) < 0)
 	FAILX(-1, "file_send");
 
@@ -102,6 +111,12 @@ receive_file_data(const int fd, const char *filename, const struct file_info *re
 	    FAIL(-1, "file_info_new");
 	}
     }
+
+    char buffer[BUFSIZ];
+    sprintf(buffer, "%ld\n", local_info->size);
+
+    if (send_data(fd, buffer, strlen(buffer)) < 0)
+	FAIL(-1, "send_data");
 
     if (send_data(fd, &answer, 1) != 1)
 	FAILX(-1, "send_data");

--- a/libadjust/file.c
+++ b/libadjust/file.c
@@ -266,7 +266,7 @@ file_send_content(const int fd, struct file_info *local, const struct file_info 
     if (send_file_adjustments(fd, local, remote) < 0)
 	FAILX(-1, "send_file_adjustments");
 
-    if (send_whole_file_content(fd, local) < 0)
+    if (send_end_of_file(fd, local) < 0)
 	FAILX(-1, "send_end_of_file");
 
     return 0;
@@ -281,7 +281,7 @@ file_recv_content(const int fd, struct file_info *local, const struct file_info 
     if (file_set_size(local, remote->size) < 0)
 	FAILX(-1, "file_set_size");
 
-    if (recv_whole_file_content(fd, local) < 0)
+    if (recv_end_of_file(fd, local) < 0)
 	FAILX(-1, "recv_end_of_file");
 
     return 0;

--- a/libadjust/file_info.c
+++ b/libadjust/file_info.c
@@ -12,6 +12,7 @@ file_info_alloc(void)
     res = malloc(sizeof(*res));
     res->filename = NULL;
     res->fd = 0;
+    res->size = 0;
     res->offset = 0;
     res->data = NULL;
     return res;

--- a/libadjust/networking.c
+++ b/libadjust/networking.c
@@ -88,7 +88,7 @@ libadjust_socket_close(void)
 }
 
 int
-send_whole_file_content(const int fd, struct file_info *local)
+send_end_of_file(const int fd, struct file_info *local)
 {
     char buffer[4 * 1024];
 
@@ -107,7 +107,7 @@ send_whole_file_content(const int fd, struct file_info *local)
 }
 
 int
-recv_whole_file_content(const int fd, struct file_info *local)
+recv_end_of_file(const int fd, struct file_info *local)
 {
     char buffer[4 * 1024];
 

--- a/libadjust/networking.c
+++ b/libadjust/networking.c
@@ -90,18 +90,16 @@ libadjust_socket_close(void)
 int
 send_whole_file_content(const int fd, struct file_info *local)
 {
-    off_t data_sent = 0;
-
     char buffer[4 * 1024];
 
-    while (data_sent < local->size) {
+    while (local->offset < local->size) {
 
-	int res = read(local->fd, buffer, MIN((off_t)sizeof(buffer), local->size - data_sent));
+	int res = read(local->fd, buffer, MIN((off_t)sizeof(buffer), local->size - local->offset));
 
 	if (send_data(fd, buffer, res) != res)
 	    FAILX(-1, "send_data");
 
-	data_sent += res;
+	local->offset += res;
     }
 
     return 0;
@@ -110,12 +108,10 @@ send_whole_file_content(const int fd, struct file_info *local)
 int
 recv_whole_file_content(const int fd, struct file_info *local)
 {
-    int data_recv = 0;
-
     char buffer[4 * 1024];
 
-    while (data_recv < local->size) {
-	int expect = MIN((off_t)sizeof(buffer), local->size - data_recv);
+    while (local->offset < local->size) {
+	int expect = MIN((off_t)sizeof(buffer), local->size - local->offset);
 	int res;
 
 	if ((res = recv_data(fd, buffer, expect)) != expect)
@@ -124,7 +120,7 @@ recv_whole_file_content(const int fd, struct file_info *local)
 	if (write(local->fd, buffer, res) != res)
 	    FAIL(-1, "write");
 
-	data_recv += res;
+	local->offset += res;
     }
 
     return 0;

--- a/libadjust/networking.c
+++ b/libadjust/networking.c
@@ -267,6 +267,29 @@ recv_block_adjustments(const int fd, const struct file_info *file)
 }
 
 int
+recv_line(char *buffer, size_t length)
+{
+    char *p = buffer;
+    char *e = buffer + length;
+
+    if (recv_data(sock, p, 1) != 1)
+	FAILX(-1, "recv_data");
+
+    while (*p != '\n') {
+	p++;
+
+	if (p > e)
+	    FAILX(-1, "end of buffer reached");
+
+	if (recv_data(sock, p, 1) != 1)
+	    FAILX(-1, "recv_data");
+    }
+    *p = '\0';
+
+    return 0;
+}
+
+int
 send_data(int fd, void *data, size_t length)
 {
     int res = send(fd, data, length, 0);

--- a/libadjust/networking.c
+++ b/libadjust/networking.c
@@ -100,6 +100,7 @@ send_whole_file_content(const int fd, struct file_info *local)
 	    FAILX(-1, "send_data");
 
 	local->offset += res;
+	stats.bytes_send_raw += res;
     }
 
     return 0;
@@ -121,6 +122,7 @@ recv_whole_file_content(const int fd, struct file_info *local)
 	    FAIL(-1, "write");
 
 	local->offset += res;
+	stats.bytes_send_raw += res;
     }
 
     return 0;
@@ -236,6 +238,7 @@ send_block_adjustments(const int fd, const struct file_info *file)
 		    FAILX(-1, "send_data");
 
 		stats.adjusted_chunks += 1;
+		stats.bytes_adjusted += this_block_size;
 	    }
 	}
 	stats.adjusted_blocks += 1;
@@ -276,6 +279,7 @@ recv_block_adjustments(const int fd, const struct file_info *file)
 		    FAILX(-1, "recv_data");
 
 		stats.adjusted_chunks += 1;
+		stats.bytes_adjusted += this_block_size;
 	    }
 	}
 	stats.adjusted_blocks += 1;

--- a/libadjust/stats.c
+++ b/libadjust/stats.c
@@ -9,7 +9,8 @@ void
 libadjust_stats_print(FILE *stream)
 {
     fprintf(stream, "synchronized %ld bytes\n", stats.bytes_synchronized);
-    fprintf(stream, "%d chunks in %d blocks where adjusted\n", stats.adjusted_chunks, stats.adjusted_blocks);
+    fprintf(stream, "%ld bytes in %d chunks in %d blocks where adjusted\n", stats.bytes_adjusted, stats.adjusted_chunks, stats.adjusted_blocks);
+    fprintf(stream, "%ld bytes where send raw\n", stats.bytes_send_raw);
     fprintf(stream, "sent %ld bytes, received %ld bytes\n", stats.bytes_send, stats.bytes_recv);
 
 }


### PR DESCRIPTION
With this option set, when adjusting a file that already exist, radjust should check existing data and raw-send the missing data at end of file.

```
+----------------------------+----------+
|         SOURCE FILE        | NEW DATA |
+----------------------------+----------+
                |                  |
                |                  |
              CHECK              WRITE
                |                  |
                V                  V
+----------------------------+ - - - - -+
|      DESTINATION FILE      |          |
+----------------------------+- - - - - +
```