### PR TITLE
Only truncate destination file if it's too big

### DIFF
--- a/libadjust/file.c
+++ b/libadjust/file.c
@@ -204,8 +204,10 @@ file_close(struct file_info *file)
 int
 file_set_size(struct file_info *file, const off_t size)
 {
-    if (ftruncate(file->fd, size) < 0)
-	FAIL(-1, "ftruncate");
+    if (file->size > size) {
+	if (ftruncate(file->fd, size) < 0)
+	    FAIL(-1, "ftruncate");
+    }
 
     file->size = size;
 


### PR DESCRIPTION
This way, the destination file grows when data arrives.  In case of
interuption, the utility will quickly check that the beginning of file
is unchanged, and then return back to writting raw data.